### PR TITLE
docs: update wording to be more consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,7 +343,7 @@ Loads the defined entity factories.
 
 ```typescript
 useFactories(options?: Partial<ConnectionConfiguration>): Promise<void>
-useFactories(seeders?: string[], options?: Partial<ConnectionConfiguration>): Promise<void>
+useFactories(factories?: string[], options?: Partial<ConnectionConfiguration>): Promise<void>
 ```
 
 ### `useSeeders`


### PR DESCRIPTION
UseSeeders has been renamed to UseFactories, to stay consistent, I propose we also change this in the README section to comply with the actual implementation :)