### PR TITLE
Seeder superclass warning and error

### DIFF
--- a/src/utils/commandUtils.ts
+++ b/src/utils/commandUtils.ts
@@ -25,7 +25,13 @@ export class CommandUtils {
       const instance = new seederExport()
       if (instance instanceof Seeder) {
         seeders.push(seederExport)
+      } else {
+        console.warning(`Seeder ${seederExport.name} is not an instanceof Seeder. Ignoring file.`);
       }
+    }
+
+    if (seeders.length === 0) {
+      throw new Error(`No valid default seeders found`)
     }
 
     return seeders


### PR DESCRIPTION
> This will warn users about inoperable seeder classes, throwing on the worst case that all seeders are inoperable.

Migrating from the fork origin, I found that I had `implements Seeder` instead of `extends Seeder`, which is compilable but invalid. The CLI said it could find the seeders, and that it had executed them. But I had no results. This was because the `seeders` sent to `useSeeders` was an empty array.

It might be worth adding a similar check in `useSeeders` to keep it reusable but up to you 🤷 